### PR TITLE
Resolve 1440px dashboard layout conflict & keep notification nav buttons inside div

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/css/site.css
+++ b/MediaBrowser.WebDashboard/dashboard-ui/css/site.css
@@ -822,7 +822,7 @@ progress {
     }
 
         .firstDashboardHomeRightColumn .ui-collapsible-content {
-            height: 585px;
+            min-height: 585px;
         }
 }
 

--- a/MediaBrowser.WebDashboard/dashboard-ui/css/site.css
+++ b/MediaBrowser.WebDashboard/dashboard-ui/css/site.css
@@ -786,7 +786,7 @@ progress {
     color: green;
 }
 
-@media all and (max-width: 1440px) {
+@media all and (max-width: 1439px) {
 
     .dashboardHomeRightColumn {
         margin-top: 1em;


### PR DESCRIPTION
When browser is exactly 1440px, unnecessary top margin added to first
right column, resulting in uneven column alignment. Positioning of right
column is also dependent on min-width 1440px in another location.
Changing to 1439px here resolves the conflict.

When the recent activity box is full with longer activities, the nav
buttons can get pushed ouut the bottom of the div because of the height
being set explicitly. Changing to min-height fixes the problem.