### PR TITLE
Show ssl port on dashboard

### DIFF
--- a/MediaBrowser.Server.Implementations/Localization/JavaScript/javascript.json
+++ b/MediaBrowser.Server.Implementations/Localization/JavaScript/javascript.json
@@ -194,6 +194,7 @@
     "LabelVideoCodec": "Video: {0}",
     "LabelRemoteAccessUrl": "Remote access: {0}",
     "LabelRunningOnPort": "Running on port {0}.",
+    "LabelRunningOnHttpsPort": "Running on SSL port {0}.",
     "HeaderLatestFromChannel": "Latest from {0}",
     "ButtonDownload": "Download",
     "LabelUnknownLanaguage": "Unknown language",

--- a/MediaBrowser.Server.Startup.Common/ApplicationHost.cs
+++ b/MediaBrowser.Server.Startup.Common/ApplicationHost.cs
@@ -978,6 +978,7 @@ namespace MediaBrowser.Server.Startup.Common
                 MacAddress = GetMacAddress(),
                 HttpServerPortNumber = HttpServerPort,
                 UseHttps = UseHttps,
+                HttpsPortNumber = HttpsServerPort,
                 CertificatePath = CertificatePath,
                 OperatingSystem = OperatingSystemDisplayName,
                 CanSelfRestart = CanSelfRestart,

--- a/MediaBrowser.WebDashboard/dashboard-ui/scripts/dashboardpage.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/scripts/dashboardpage.js
@@ -77,9 +77,17 @@
 
             $('#appVersionNumber', page).html(Globalize.translate('LabelVersionNumber').replace('{0}', systemInfo.Version));
 
-            var port = systemInfo.HttpServerPortNumber;
+            var httpPort = systemInfo.HttpServerPortNumber;
 
-            $('#ports', page).html(Globalize.translate('LabelRunningOnPort', '<b>' + port + '</b>'));
+            var portHtml = Globalize.translate('LabelRunningOnPort', '<b>' + httpPort + '</b>');
+
+            if (systemInfo.UseHttps) {
+                var httpsPort = systemInfo.HttpsPortNumber;
+                portHtml += '<br>';
+                portHtml += Globalize.translate('LabelRunningOnHttpsPort', '<b>' + httpsPort + '</b>');
+            }
+
+            $('#ports', page).html(portHtml);
 
             if (systemInfo.CanSelfRestart) {
                 $('.btnRestartContainer', page).removeClass('hide');


### PR DESCRIPTION
I've added ssl port information to the dashboard. I only added the label to the en_US file. I'll be happy to add it in any other file. 

First: is there an automated process for this that I don't know about? 
Second, if the language isn't English do I add the english label anyway or just leave the label out?

You are probably going to get a bunch of small pulls from me at this point. I get precious little time to do any "fun" work with a job, wife, and child. Let me know if they get too granular.