### PR TITLE
Fix ssl port info on dashboard

### DIFF
--- a/MediaBrowser.Model/System/SystemInfo.cs
+++ b/MediaBrowser.Model/System/SystemInfo.cs
@@ -122,6 +122,12 @@ namespace MediaBrowser.Model.System
         /// <value>The HTTP server port number.</value>
         public int HttpServerPortNumber { get; set; }
 
+         /// <summary>
+         /// Gets or sets the value pointing to the file system where the ssl certiifcate is located.
+         /// </summary>
+         /// <value>The value pointing to the file system where the ssl certiifcate is located.</value>
+         public bool UseHttps { get; set; }
+
         /// <summary>
         /// Gets or sets the HTTPS server port number.
         /// </summary>

--- a/MediaBrowser.Server.Startup.Common/ApplicationHost.cs
+++ b/MediaBrowser.Server.Startup.Common/ApplicationHost.cs
@@ -965,6 +965,7 @@ namespace MediaBrowser.Server.Startup.Common
                 CachePath = ApplicationPaths.CachePath,
                 MacAddress = GetMacAddress(),
                 HttpServerPortNumber = HttpServerPort,
+                UseHttps = this.ServerConfigurationManager.Configuration.UseHttps,
                 HttpsPortNumber = HttpsServerPort,
                 OperatingSystem = OperatingSystemDisplayName,
                 CanSelfRestart = CanSelfRestart,


### PR DESCRIPTION
The UseHttps property on the systeminfo class is used by the dashboard javascript. If this isn't the correct fix please let me know what is.