### PR TITLE
Fix DLNA status reporting

### DIFF
--- a/MediaBrowser.Dlna/PlayTo/PlayToController.cs
+++ b/MediaBrowser.Dlna/PlayTo/PlayToController.cs
@@ -272,7 +272,7 @@ namespace MediaBrowser.Dlna.PlayTo
 
             return new PlaybackStartInfo
             {
-                ItemId = mediaInfo.Id,
+                ItemId = info.Item.Id.ToString(),
                 SessionId = _session.Id,
                 PositionTicks = ticks,
                 IsMuted = _device.IsMuted,


### PR DESCRIPTION
mediaInfo.Id is some long URL that ends with: Params=;uuid:8656a761-9b0c-868a-df35-d87147340fe8;88394665c46386ac96e5c3492b870ced;true;;;;;;;;;;;0;;;;;;"

I think item Id is what we want here. Is there a reason ItemId on PlaybackStartInfo is not of type Guid?