### PR TITLE
Bluebull32 patch 1

### DIFF
--- a/MediaBrowser.Api/Playback/BifService.cs
+++ b/MediaBrowser.Api/Playback/BifService.cs
@@ -155,7 +155,7 @@ namespace MediaBrowser.Api.Playback
         private byte[] GetBytes(int value)
         {
             byte[] bytes = BitConverter.GetBytes(value);
-            if (BitConverter.IsLittleEndian)
+            if (!BitConverter.IsLittleEndian)
                 Array.Reverse(bytes);
             return bytes;
         }

--- a/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
+++ b/MediaBrowser.MediaEncoding/Encoder/MediaEncoder.cs
@@ -501,7 +501,21 @@ namespace MediaBrowser.MediaEncoding.Encoder
 
             process.Start();
 
-            var ranToCompletion = process.WaitForExit(120000);
+            // Need to give ffmpeg enough time to make all the thumbnails, which could be a while,
+            // but we still need to detect if the process hangs.
+            // Making the assumption that as long as new jpegs are showing up, everything is good.
+
+            bool isResponsive = true;
+            int lastCount = 0;
+
+            while (isResponsive && !process.WaitForExit(120000))
+            {
+                int jpegCount = Directory.GetFiles(targetDirectory, "*.jpg").Count();
+                isResponsive = (jpegCount > lastCount);
+                lastCount = jpegCount;
+            }
+
+            bool ranToCompletion = process.HasExited;
 
             if (!ranToCompletion)
             {


### PR DESCRIPTION
BIF related fixes:
1) Give ffmpeg more time to create thumbnails, but periodically check to make sure the process did not hang.
2) Reverse Endianness for integer values in the index.bif file.