### PR TITLE
TV Guide starts at current time and is based on 1 minute increments

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/css/livetv.css
+++ b/MediaBrowser.WebDashboard/dashboard-ui/css/livetv.css
@@ -158,7 +158,6 @@
 .timeslotCell {
     display: inline-block;
     border-bottom: 1px solid #444;
-    border-left: 1px solid #444;
     border-collapse: collapse;
     position: relative;
 }
@@ -216,8 +215,11 @@
     margin-left: 190px;
 }
 
-.timeslotCell, .timeslotHeader {
-    width: 190px;
+.timeslotHeader {
+    width: 179px;
+}
+.timeslotCell {
+	width: 6px;/* (180/30 min) */
 }
 
 .timeslotCellInner {
@@ -233,6 +235,7 @@
 }
 
 .timeslotCellInnerWithProgram {
+	border-left: 1px solid #444;
     z-index: 99;
 }
 


### PR DESCRIPTION
This is an update to pull request #998 that includes starting the guide at the current time instead of the beginning of the current hour (and therefore showing potentially ended shows)