### PR TITLE
Update TvShowsService.cs

### DIFF
--- a/MediaBrowser.Api/TvShowsService.cs
+++ b/MediaBrowser.Api/TvShowsService.cs
@@ -494,7 +494,7 @@ namespace MediaBrowser.Api
 
             return new ItemsResult
             {
-                TotalRecordCount = dtos.Length,
+                TotalRecordCount = returnItems.Count(),
                 Items = dtos
             };
         }


### PR DESCRIPTION
Fix for 25 episode limit on Roku app:  "TotalRecordCount" in line 497 needs to be total episodes in season, not the number of episodes returned in this query response.