### PR TITLE
Prototype of max task length for scheduled tasks.

### DIFF
--- a/MediaBrowser.Api/ScheduledTasks/ScheduledTaskService.cs
+++ b/MediaBrowser.Api/ScheduledTasks/ScheduledTaskService.cs
@@ -195,7 +195,7 @@ namespace MediaBrowser.Api.ScheduledTasks
                 throw new ResourceNotFoundException("Task not found");
             }
 
-            TaskManager.Execute(task);
+            TaskManager.Execute(task, null);
         }
 
         /// <summary>

--- a/MediaBrowser.Common.Implementations/ScheduledTasks/TaskManager.cs
+++ b/MediaBrowser.Common.Implementations/ScheduledTasks/TaskManager.cs
@@ -29,7 +29,7 @@ namespace MediaBrowser.Common.Implementations.ScheduledTasks
         /// <summary>
         /// The _task queue
         /// </summary>
-        private readonly List<Type> _taskQueue = new List<Type>();
+        private readonly SortedDictionary<Type, TaskExecutionOptions> _taskQueue = new SortedDictionary<Type, TaskExecutionOptions>();
 
         /// <summary>
         /// Gets or sets the json serializer.
@@ -69,13 +69,14 @@ namespace MediaBrowser.Common.Implementations.ScheduledTasks
         /// Cancels if running and queue.
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        public void CancelIfRunningAndQueue<T>()
+        /// <param name="options">Task options.</param>
+        public void CancelIfRunningAndQueue<T>(TaskExecutionOptions options)
                  where T : IScheduledTask
         {
             var task = ScheduledTasks.First(t => t.ScheduledTask.GetType() == typeof(T));
             ((ScheduledTaskWorker)task).CancelIfRunning();
 
-            QueueScheduledTask<T>();
+            QueueScheduledTask<T>(options);
         }
 
         /// <summary>
@@ -93,30 +94,33 @@ namespace MediaBrowser.Common.Implementations.ScheduledTasks
         /// Queues the scheduled task.
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        public void QueueScheduledTask<T>()
+        /// <param name="options">Task options</param>
+        public void QueueScheduledTask<T>(TaskExecutionOptions options)
             where T : IScheduledTask
         {
             var scheduledTask = ScheduledTasks.First(t => t.ScheduledTask.GetType() == typeof(T));
 
-            QueueScheduledTask(scheduledTask);
+            QueueScheduledTask(scheduledTask, options);
         }
 
         /// <summary>
         /// Queues the scheduled task.
         /// </summary>
         /// <param name="task">The task.</param>
-        public void QueueScheduledTask(IScheduledTask task)
+        /// <param name="options">The task options.</param>
+        public void QueueScheduledTask(IScheduledTask task, TaskExecutionOptions options)
         {
             var scheduledTask = ScheduledTasks.First(t => t.ScheduledTask.GetType() == task.GetType());
 
-            QueueScheduledTask(scheduledTask);
+            QueueScheduledTask(scheduledTask, options);
         }
 
         /// <summary>
         /// Queues the scheduled task.
         /// </summary>
         /// <param name="task">The task.</param>
-        private void QueueScheduledTask(IScheduledTaskWorker task)
+        /// <param name="options">The task options.</param>
+        private void QueueScheduledTask(IScheduledTaskWorker task, TaskExecutionOptions options)
         {
             var type = task.ScheduledTask.GetType();
 
@@ -125,17 +129,18 @@ namespace MediaBrowser.Common.Implementations.ScheduledTasks
                 // If it's idle just execute immediately
                 if (task.State == TaskState.Idle)
                 {
-                    Execute(task);
+                    Execute(task, options);
                     return;
                 }
 
-                if (!_taskQueue.Contains(type))
+                if (!_taskQueue.ContainsKey(type))
                 {
                     Logger.Info("Queueing task {0}", type.Name);
-                    _taskQueue.Add(type);
+                    _taskQueue.Add(type, options);
                 }
                 else
                 {
+                    _taskQueue[type] = options;
                     Logger.Info("Task already queued: {0}", type.Name);
                 }
             }
@@ -181,9 +186,9 @@ namespace MediaBrowser.Common.Implementations.ScheduledTasks
             ((ScheduledTaskWorker)task).Cancel();
         }
 
-        public Task Execute(IScheduledTaskWorker task)
+        public Task Execute(IScheduledTaskWorker task, TaskExecutionOptions options)
         {
-            return ((ScheduledTaskWorker)task).Execute();
+            return ((ScheduledTaskWorker)task).Execute(options);
         }
 
         /// <summary>
@@ -224,15 +229,15 @@ namespace MediaBrowser.Common.Implementations.ScheduledTasks
             // Execute queued tasks
             lock (_taskQueue)
             {
-                foreach (var type in _taskQueue.ToList())
+                foreach (var enqueuedType in _taskQueue.ToList())
                 {
-                    var scheduledTask = ScheduledTasks.First(t => t.ScheduledTask.GetType() == type);
+                    var scheduledTask = ScheduledTasks.First(t => t.ScheduledTask.GetType() == enqueuedType.Key);
 
                     if (scheduledTask.State == TaskState.Idle)
                     {
-                        Execute(scheduledTask);
+                        Execute(scheduledTask, enqueuedType.Value);
 
-                        _taskQueue.Remove(type);
+                        _taskQueue.Remove(enqueuedType.Key);
                     }
                 }
             }

--- a/MediaBrowser.Common/MediaBrowser.Common.csproj
+++ b/MediaBrowser.Common/MediaBrowser.Common.csproj
@@ -86,6 +86,7 @@
     <Compile Include="ScheduledTasks\DailyTrigger.cs" />
     <Compile Include="ScheduledTasks\IntervalTrigger.cs" />
     <Compile Include="ScheduledTasks\TaskCompletionEventArgs.cs" />
+    <Compile Include="ScheduledTasks\TaskExecutionOptions.cs" />
     <Compile Include="ScheduledTasks\WeeklyTrigger.cs" />
     <Compile Include="Security\IRequiresRegistration.cs" />
     <Compile Include="Security\ISecurityManager.cs" />

--- a/MediaBrowser.Common/ScheduledTasks/DailyTrigger.cs
+++ b/MediaBrowser.Common/ScheduledTasks/DailyTrigger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using MediaBrowser.Model.Events;
 
 namespace MediaBrowser.Common.ScheduledTasks
 {
@@ -19,6 +20,14 @@ namespace MediaBrowser.Common.ScheduledTasks
         /// </summary>
         /// <value>The timer.</value>
         private Timer Timer { get; set; }
+
+        /// <summary>
+        /// Gets the execution properties of this task.
+        /// </summary>
+        /// <value>
+        /// The execution properties of this task.
+        /// </value>
+        public TaskExecutionOptions TaskOptions { get; set; }
 
         /// <summary>
         /// Stars waiting for the trigger action
@@ -58,7 +67,7 @@ namespace MediaBrowser.Common.ScheduledTasks
         /// <summary>
         /// Occurs when [triggered].
         /// </summary>
-        public event EventHandler<EventArgs> Triggered;
+        public event EventHandler<GenericEventArgs<TaskExecutionOptions>> Triggered;
 
         /// <summary>
         /// Called when [triggered].
@@ -67,7 +76,7 @@ namespace MediaBrowser.Common.ScheduledTasks
         {
             if (Triggered != null)
             {
-                Triggered(this, EventArgs.Empty);
+                Triggered(this, new GenericEventArgs<TaskExecutionOptions>(TaskOptions));
             }
         }
     }

--- a/MediaBrowser.Common/ScheduledTasks/ITaskManager.cs
+++ b/MediaBrowser.Common/ScheduledTasks/ITaskManager.cs
@@ -17,7 +17,8 @@ namespace MediaBrowser.Common.ScheduledTasks
         /// Cancels if running and queue.
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        void CancelIfRunningAndQueue<T>()
+        /// <param name="options">Task options.</param>
+        void CancelIfRunningAndQueue<T>(TaskExecutionOptions options)
             where T : IScheduledTask;
 
         /// <summary>
@@ -31,14 +32,16 @@ namespace MediaBrowser.Common.ScheduledTasks
         /// Queues the scheduled task.
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        void QueueScheduledTask<T>()
+        /// <param name="options">Task options.</param>
+        void QueueScheduledTask<T>(TaskExecutionOptions options)
             where T : IScheduledTask;
 
         /// <summary>
         /// Queues the scheduled task.
         /// </summary>
         /// <param name="task">The task.</param>
-        void QueueScheduledTask(IScheduledTask task);
+        /// <param name="options">The task run options.</param>
+        void QueueScheduledTask(IScheduledTask task, TaskExecutionOptions options);
 
         /// <summary>
         /// Adds the tasks.
@@ -47,7 +50,7 @@ namespace MediaBrowser.Common.ScheduledTasks
         void AddTasks(IEnumerable<IScheduledTask> tasks);
 
         void Cancel(IScheduledTaskWorker task);
-        Task Execute(IScheduledTaskWorker task);
+        Task Execute(IScheduledTaskWorker task, TaskExecutionOptions options);
 
         event EventHandler<GenericEventArgs<IScheduledTaskWorker>> TaskExecuting;
         event EventHandler<TaskCompletionEventArgs> TaskCompleted;

--- a/MediaBrowser.Common/ScheduledTasks/ITaskTrigger.cs
+++ b/MediaBrowser.Common/ScheduledTasks/ITaskTrigger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using MediaBrowser.Model.Events;
 
 namespace MediaBrowser.Common.ScheduledTasks
 {
@@ -10,7 +11,7 @@ namespace MediaBrowser.Common.ScheduledTasks
         /// <summary>
         /// Fires when the trigger condition is satisfied and the task should run
         /// </summary>
-        event EventHandler<EventArgs> Triggered;
+        event EventHandler<GenericEventArgs<TaskExecutionOptions>> Triggered;
 
         /// <summary>
         /// Stars waiting for the trigger action
@@ -22,5 +23,13 @@ namespace MediaBrowser.Common.ScheduledTasks
         /// Stops waiting for the trigger action
         /// </summary>
         void Stop();
+
+        /// <summary>
+        /// Gets or sets the execution properties of this task.
+        /// </summary>
+        /// <value>
+        /// The execution properties of this task.
+        /// </value>
+        TaskExecutionOptions TaskOptions { get; set; }
     }
 }

--- a/MediaBrowser.Common/ScheduledTasks/IntervalTrigger.cs
+++ b/MediaBrowser.Common/ScheduledTasks/IntervalTrigger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using MediaBrowser.Model.Events;
 
 namespace MediaBrowser.Common.ScheduledTasks
 {
@@ -19,6 +20,14 @@ namespace MediaBrowser.Common.ScheduledTasks
         /// </summary>
         /// <value>The timer.</value>
         private Timer Timer { get; set; }
+
+        /// <summary>
+        /// Gets the execution properties of this task.
+        /// </summary>
+        /// <value>
+        /// The execution properties of this task.
+        /// </value>
+        public TaskExecutionOptions TaskOptions { get; set; }
 
         /// <summary>
         /// Stars waiting for the trigger action
@@ -53,7 +62,7 @@ namespace MediaBrowser.Common.ScheduledTasks
         /// <summary>
         /// Occurs when [triggered].
         /// </summary>
-        public event EventHandler<EventArgs> Triggered;
+        public event EventHandler<GenericEventArgs<TaskExecutionOptions>> Triggered;
 
         /// <summary>
         /// Called when [triggered].
@@ -62,7 +71,7 @@ namespace MediaBrowser.Common.ScheduledTasks
         {
             if (Triggered != null)
             {
-                Triggered(this, EventArgs.Empty);
+                Triggered(this, new GenericEventArgs<TaskExecutionOptions>(TaskOptions));
             }
         }
     }

--- a/MediaBrowser.Common/ScheduledTasks/StartupTrigger.cs
+++ b/MediaBrowser.Common/ScheduledTasks/StartupTrigger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using MediaBrowser.Model.Events;
 
 namespace MediaBrowser.Common.ScheduledTasks
 {
@@ -9,6 +10,14 @@ namespace MediaBrowser.Common.ScheduledTasks
     public class StartupTrigger : ITaskTrigger
     {
         public int DelayMs { get; set; }
+
+        /// <summary>
+        /// Gets the execution properties of this task.
+        /// </summary>
+        /// <value>
+        /// The execution properties of this task.
+        /// </value>
+        public TaskExecutionOptions TaskOptions { get; set; }
 
         public StartupTrigger()
         {
@@ -39,7 +48,7 @@ namespace MediaBrowser.Common.ScheduledTasks
         /// <summary>
         /// Occurs when [triggered].
         /// </summary>
-        public event EventHandler<EventArgs> Triggered;
+        public event EventHandler<GenericEventArgs<TaskExecutionOptions>> Triggered;
 
         /// <summary>
         /// Called when [triggered].
@@ -48,7 +57,7 @@ namespace MediaBrowser.Common.ScheduledTasks
         {
             if (Triggered != null)
             {
-                Triggered(this, EventArgs.Empty);
+                Triggered(this, new GenericEventArgs<TaskExecutionOptions>(TaskOptions));
             }
         }
     }

--- a/MediaBrowser.Common/ScheduledTasks/SystemEventTrigger.cs
+++ b/MediaBrowser.Common/ScheduledTasks/SystemEventTrigger.cs
@@ -2,6 +2,7 @@
 using Microsoft.Win32;
 using System;
 using System.Threading.Tasks;
+using MediaBrowser.Model.Events;
 
 namespace MediaBrowser.Common.ScheduledTasks
 {
@@ -15,6 +16,14 @@ namespace MediaBrowser.Common.ScheduledTasks
         /// </summary>
         /// <value>The system event.</value>
         public SystemEvent SystemEvent { get; set; }
+
+        /// <summary>
+        /// Gets the execution properties of this task.
+        /// </summary>
+        /// <value>
+        /// The execution properties of this task.
+        /// </value>
+        public TaskExecutionOptions TaskOptions { get; set; }
 
         /// <summary>
         /// Stars waiting for the trigger action
@@ -57,7 +66,7 @@ namespace MediaBrowser.Common.ScheduledTasks
         /// <summary>
         /// Occurs when [triggered].
         /// </summary>
-        public event EventHandler<EventArgs> Triggered;
+        public event EventHandler<GenericEventArgs<TaskExecutionOptions>> Triggered;
 
         /// <summary>
         /// Called when [triggered].
@@ -66,7 +75,7 @@ namespace MediaBrowser.Common.ScheduledTasks
         {
             if (Triggered != null)
             {
-                Triggered(this, EventArgs.Empty);
+                Triggered(this, new GenericEventArgs<TaskExecutionOptions>(TaskOptions));
             }
         }
     }

--- a/MediaBrowser.Common/ScheduledTasks/TaskExecutionOptions.cs
+++ b/MediaBrowser.Common/ScheduledTasks/TaskExecutionOptions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MediaBrowser.Common.ScheduledTasks
+{
+    /// <summary>
+    /// A class that encomposases all common task run properties.
+    /// </summary>
+    public class TaskExecutionOptions
+    {
+        public int? EllapsedTimeMs { get; set; }
+    }
+}

--- a/MediaBrowser.Common/ScheduledTasks/WeeklyTrigger.cs
+++ b/MediaBrowser.Common/ScheduledTasks/WeeklyTrigger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using MediaBrowser.Model.Events;
 
 namespace MediaBrowser.Common.ScheduledTasks
 {
@@ -19,6 +20,14 @@ namespace MediaBrowser.Common.ScheduledTasks
         /// </summary>
         /// <value>The day of week.</value>
         public DayOfWeek DayOfWeek { get; set; }
+
+        /// <summary>
+        /// Gets the execution properties of this task.
+        /// </summary>
+        /// <value>
+        /// The execution properties of this task.
+        /// </value>
+        public TaskExecutionOptions TaskOptions { get; set; }
 
         /// <summary>
         /// Gets or sets the timer.
@@ -88,7 +97,7 @@ namespace MediaBrowser.Common.ScheduledTasks
         /// <summary>
         /// Occurs when [triggered].
         /// </summary>
-        public event EventHandler<EventArgs> Triggered;
+        public event EventHandler<GenericEventArgs<TaskExecutionOptions>> Triggered;
 
         /// <summary>
         /// Called when [triggered].
@@ -97,7 +106,7 @@ namespace MediaBrowser.Common.ScheduledTasks
         {
             if (Triggered != null)
             {
-                Triggered(this, EventArgs.Empty);
+                Triggered(this, new GenericEventArgs<TaskExecutionOptions>(TaskOptions));
             }
         }
     }

--- a/MediaBrowser.Server.Implementations/FileOrganization/FileOrganizationService.cs
+++ b/MediaBrowser.Server.Implementations/FileOrganization/FileOrganizationService.cs
@@ -41,7 +41,7 @@ namespace MediaBrowser.Server.Implementations.FileOrganization
 
         public void BeginProcessNewFiles()
         {
-            _taskManager.CancelIfRunningAndQueue<OrganizerScheduledTask>();
+            _taskManager.CancelIfRunningAndQueue<OrganizerScheduledTask>(null);
         }
 
         public Task SaveResult(FileOrganizationResult result, CancellationToken cancellationToken)

--- a/MediaBrowser.Server.Implementations/IO/LibraryMonitor.cs
+++ b/MediaBrowser.Server.Implementations/IO/LibraryMonitor.cs
@@ -574,7 +574,7 @@ namespace MediaBrowser.Server.Implementations.IO
             // If the root folder changed, run the library task so the user can see it
             if (itemsToRefresh.Any(i => i is AggregateFolder))
             {
-                TaskManager.CancelIfRunningAndQueue<RefreshMediaLibraryTask>();
+                TaskManager.CancelIfRunningAndQueue<RefreshMediaLibraryTask>(null);
                 return;
             }
 

--- a/MediaBrowser.Server.Implementations/Library/LibraryManager.cs
+++ b/MediaBrowser.Server.Implementations/Library/LibraryManager.cs
@@ -293,7 +293,7 @@ namespace MediaBrowser.Server.Implementations.Library
 
                 if (seasonZeroNameChanged || ibnPathChanged || wizardChanged)
                 {
-                    _taskManager.CancelIfRunningAndQueue<RefreshMediaLibraryTask>();
+                    _taskManager.CancelIfRunningAndQueue<RefreshMediaLibraryTask>(null);
                 }
             });
         }
@@ -992,7 +992,7 @@ namespace MediaBrowser.Server.Implementations.Library
         public Task ValidateMediaLibrary(IProgress<double> progress, CancellationToken cancellationToken)
         {
             // Just run the scheduled task so that the user can see it
-            _taskManager.CancelIfRunningAndQueue<RefreshMediaLibraryTask>();
+            _taskManager.CancelIfRunningAndQueue<RefreshMediaLibraryTask>(null);
 
             return Task.FromResult(true);
         }
@@ -1003,7 +1003,7 @@ namespace MediaBrowser.Server.Implementations.Library
         public void QueueLibraryScan()
         {
             // Just run the scheduled task so that the user can see it
-            _taskManager.QueueScheduledTask<RefreshMediaLibraryTask>();
+            _taskManager.QueueScheduledTask<RefreshMediaLibraryTask>(null);
         }
 
         /// <summary>

--- a/MediaBrowser.Server.Implementations/LiveTv/LiveTvManager.cs
+++ b/MediaBrowser.Server.Implementations/LiveTv/LiveTvManager.cs
@@ -131,7 +131,7 @@ namespace MediaBrowser.Server.Implementations.LiveTv
 
         void service_DataSourceChanged(object sender, EventArgs e)
         {
-            _taskManager.CancelIfRunningAndQueue<RefreshChannelsScheduledTask>();
+            _taskManager.CancelIfRunningAndQueue<RefreshChannelsScheduledTask>(null);
         }
 
         public async Task<QueryResult<LiveTvChannel>> GetInternalChannels(LiveTvChannelQuery query, CancellationToken cancellationToken)


### PR DESCRIPTION
Here is a prototype of what I am thinking for capping task runtime. There are a handful of issues to discuss.

Should the task runtime be a property of the task or the trigger? Right now it's just hard coded for a sample. Making it part of the task seems natural except it would not be possible to make the runtime variable based upon the time of day. I don't know if we care about this.

The task needs to be smart enough to know how to make progress each time the task is activated. If the task always takes an hour, but is only allocated 30 minutes it will always do the first 50%. For BIF creation this shouldn't be an issue since it will pick up where it left off. What about other tasks that may want a time cap?

Can I modify IScheduledTask or ITaskTrigger? Are these public APIs? How do plugins use them? I usually use base classes for these types of thing with an interface so you can add members with sensible defaults, but existing binaries continue to work.