### PR TITLE
Add clear button back into auto organize page

### DIFF
--- a/MediaBrowser.WebDashboard/dashboard-ui/autoorganizelog.html
+++ b/MediaBrowser.WebDashboard/dashboard-ui/autoorganizelog.html
@@ -18,8 +18,8 @@
                     <div class="listTopPaging" style="float: left; position: relative; top: 15px;">
                     </div>
 
-                    <!--<button style="display: none;" class="btnClearLog" type="button" data-inline="true" data-icon="forbidden" data-mini="true">Clear</button>-->
                     <div style="float: right; position: relative; top: 15px;margin-top: -5px;display:none;" class="organizeTaskPanel">
+                        <button type="button" class="btnClearLog" data-icon="forbidden" data-mini="true" data-inline="true" style="display: none;">Clear</button>
                         <button type="button" class="btnOrganize" data-icon="action" data-mini="true" data-inline="true">${ButtonOrganize}</button>
                         <progress max="100" min="0" style="width:100px;display:none;" class="organizeProgress"></progress>
                     </div>


### PR DESCRIPTION
Apparently the clear button in the auto-organize page was removed during the dashboard redesign and people have been asking for it's return.