### PR TITLE
Fix season images not showing up when Emby starts.

### DIFF
--- a/MediaBrowser.Controller/Entities/TV/Series.cs
+++ b/MediaBrowser.Controller/Entities/TV/Series.cs
@@ -232,7 +232,10 @@ namespace MediaBrowser.Controller.Entities.TV
             refreshOptions = new MetadataRefreshOptions(refreshOptions);
             refreshOptions.IsPostRecursiveRefresh = true;
 
-            // Refresh songs
+            // Refresh current item
+            await RefreshMetadata(refreshOptions, cancellationToken).ConfigureAwait(false);
+
+            // Refresh TV
             foreach (var item in seasons)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -244,9 +247,6 @@ namespace MediaBrowser.Controller.Entities.TV
                 percent /= totalItems;
                 progress.Report(percent * 100);
             }
-
-            // Refresh current item
-            await RefreshMetadata(refreshOptions, cancellationToken).ConfigureAwait(false);
 
             // Refresh all non-songs
             foreach (var item in otherItems)


### PR DESCRIPTION
The TvdbSeasonImageProvider was running before the TvdbSeasonImageProvider. This caused the seriesid be null on the series. (This is apparently populated as part of the metadata refresh on the series.) Moving that scan before the seasons seems to fix the problem.

See the following code from TvdbSeriesImageProvider

var seriesId = series != null ? series.GetProviderId(MetadataProviders.Tvdb) : null;
if (!string.IsNullOrEmpty(seriesId) && season.IndexNumber.HasValue)