### PR TITLE
Don't use DirectoryNotFound exception for control flow.

### DIFF
--- a/MediaBrowser.Controller/Providers/DirectoryService.cs
+++ b/MediaBrowser.Controller/Providers/DirectoryService.cs
@@ -55,21 +55,24 @@ namespace MediaBrowser.Controller.Providers
                 //_logger.Debug("Getting files for " + path);
 
                 entries = new Dictionary<string, FileSystemInfo>(StringComparer.OrdinalIgnoreCase);
-                
-                try
-                {
-                    var list = new DirectoryInfo(path)
-                        .EnumerateFileSystemInfos("*", SearchOption.TopDirectoryOnly);
 
-                    // Seeing dupes on some users file system for some reason
-                    foreach (var item in list)
-                    {
-                        entries[item.FullName] = item;
-                    }
-                }
-                catch (DirectoryNotFoundException)
+                if (Directory.Exists(path))
                 {
-                }
+                    try
+                    {
+                        var list = new DirectoryInfo(path)
+                            .EnumerateFileSystemInfos("*", SearchOption.TopDirectoryOnly);
+
+                        // Seeing dupes on some users file system for some reason
+                        foreach (var item in list)
+                        {
+                            entries[item.FullName] = item;
+                        }
+                    }
+                    catch (DirectoryNotFoundException)
+                    {
+                    }   
+                }                
 
                 //var group = entries.ToLookup(i => Path.GetDirectoryName(i.FullName)).ToList();
 


### PR DESCRIPTION
This reduces the time to scan a 25k photo collection from

13 minute(s) and 18 seconds

To

1 minute(s) and 31 seconds